### PR TITLE
fix: enhance boolean attribute setting to handle numeric string values

### DIFF
--- a/custom_components/midea_auto_cloud/midea_entity.py
+++ b/custom_components/midea_auto_cloud/midea_entity.py
@@ -222,7 +222,15 @@ class MideaEntity(CoordinatorEntity[MideaDataUpdateCoordinator], Entity):
         """Set boolean attribute via coordinator, no-op if key is None."""
         if attribute_key is None:
             return
-        await self.async_set_attribute(attribute_key, self._rationale[int(turn_on)])
+        
+        # Check current value to determine if we need to use 0/1 instead of off/on
+        current_value = self._get_nested_value(attribute_key)
+        if isinstance(current_value, str) and current_value in ['0', '1']:
+            # Device uses numeric strings, so use 0/1
+            await self.async_set_attribute(attribute_key, '1' if turn_on else '0')
+        else:
+            # Use the default rationale
+            await self.async_set_attribute(attribute_key, self._rationale[int(turn_on)])
 
     def _list_get_selected(self, key_of_list: list, rationale: Rationale = Rationale.EQUALLY):
         for index in range(0, len(key_of_list)):


### PR DESCRIPTION
日志如下：
日志记录器: custom_components.midea_auto_cloud.midea_entity
来源: custom_components/midea_auto_cloud/core/logger.py:25
集成: Midea Auto Cloud (文档, 问题)
首次出现: 12:57:36 (647 次出现)
上次记录: 13:02:00
The value of attribute dry_zone ('0') is not in rationale ['off', 'on']
The value of attribute electronic_smell ('0') is not in rationale ['off', 'on']
The value of attribute eradicate_pesticide_residue ('0') is not in rationale ['off', 'on']
The value of attribute performance_mode ('0') is not in rationale ['off', 'on']
The value of attribute ice_mouth_power ('0') is not in rationale ['off', 'on']

存在一些实体的API返回状态和实体状态字典不符合的情况，有时候返回状态是off/on而实体要求0/1，反之亦然，这些错误形成了非常多的日志文件。增加了0/1值和off/on的对应转化逻辑使其不再报错。