### PR TITLE
fix: 移除手动设置 entity_id 以修复实体注册失败

### DIFF
--- a/custom_components/midea_auto_cloud/midea_entity.py
+++ b/custom_components/midea_auto_cloud/midea_entity.py
@@ -84,7 +84,6 @@ class MideaEntity(CoordinatorEntity[MideaDataUpdateCoordinator], Entity):
             name_cfg = self._config.get("name")
             if name_cfg is not None:
                 self._attr_name = f"{name_cfg}"
-            self.entity_id = self._attr_unique_id
             # Register device updates for HA state refresh
             try:
                 self._device.register_update(self.update_state)  # type: ignore[attr-defined]


### PR DESCRIPTION
移除基类中手动设置 entity_id 为 unique_id 的代码，让 Home Assistant 自动生成合法的 entity_id。
解决 Status 实体因包含大写字母导致注册时抛出 Invalid entity ID 错误的问题。

Homeassistant 版本：Core 2026.3.0.dev202602010311

日志记录器: homeassistant.components.binary_sensor
来源: helpers/entity_platform.py:679
集成: 二元传感器 (文档, 问题)
首次出现: 11:24:08 (8 次出现)
上次记录: 11:24:08
Error adding entity midea_auto_cloud.222222222222222_Status for domain binary_sensor with platform midea_auto_cloud

Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 679, in _async_add_entities
await self._async_add_entity(
entity, False, entity_registry, config_subentry_id
)
File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 826, in _async_add_entity
raise HomeAssistantError(f"Invalid entity ID: {entity.entity_id}")
homeassistant.exceptions.HomeAssistantError: Invalid entity ID: midea_auto_cloud.22222222222222_Status 