### PR TITLE
fix(fan): correctly merge preset mode status on turn on

### DIFF
--- a/custom_components/midea_auto_cloud/fan.py
+++ b/custom_components/midea_auto_cloud/fan.py
@@ -141,7 +141,9 @@ class MideaFanEntity(MideaEntity, FanEntity):
         new_status = {}
         if preset_mode is not None and self._key_preset_modes is not None:
             mode_config = self._key_preset_modes.get(preset_mode, {})
-            new_status.update = mode_config
+            new_status.update(
+                {key: value for key, value in mode_config.items() if key != "speeds"}
+            )
         
             # 切换到该模式的档位配置
             if "speeds" in mode_config:


### PR DESCRIPTION
# PR 草稿：修复 fan preset turn_on 时状态合并错误

## 标题

fix(fan): correctly merge preset mode status on turn on

## 正文

### 这个 PR 改了什么

这个 PR 修复 `MideaFanEntity.async_turn_on(preset_mode=...)` 中 preset mode 状态合并逻辑的问题。

当前代码里存在类似逻辑：

```python
new_status.update = mode_config
```

这里并不是在调用 `dict.update(...)`，而是在尝试给 `dict.update` 方法赋值。`dict.update` 是只读方法，因此当用户通过 `fan.turn_on` 并传入 `preset_mode` 时，这段逻辑可能触发 `AttributeError`，导致 preset 模式无法正常打开。

修复后应改为真正合并 dict：

```python
new_status.update(...)
```

同时，`mode_config` 里可能包含 `speeds` 这类只用于 HA entity 内部逻辑的嵌套配置，不应该直接作为设备控制属性发给设备。因此合并 status 时应排除 `speeds`，只发送真实设备属性。

### 为什么需要这个修改

这个修改解决的是一个明确的运行时 bug：

1. **preset fan turn_on 可能崩溃**  
   `new_status.update = mode_config` 会尝试覆盖 dict 的内置方法，而不是更新状态内容。

2. **避免把非设备控制字段发给设备**  
   `speeds` 是 entity 层配置，不是设备属性。直接放入 `new_status` 可能导致无效 payload 或不可预期行为。

3. **保持现有行为最小变更**  
   这个 PR 只修复 fan preset turn_on 的 status 合并逻辑，不改变设备 mapping、不新增实体、不调整 climate 行为。

### 这个 PR 解决什么问题

修复后，当调用类似下面的服务时：

```yaml
service: fan.turn_on
target:
  entity_id: fan.xxx
data:
  preset_mode: some_mode
```

集成会正确：

- 读取 preset mode 对应的设备属性
- 合并到 `new_status`
- 按需切换当前 speeds 配置
- 不再因为 `dict.update` 被错误赋值而抛出异常

### 本地验证

本地 Home Assistant 配置检查通过。

测试后检查了系统日志，没有发现与以下内容相关的错误或 traceback：

- `custom_components.midea_auto_cloud.fan`
- `fan_only`
- `Traceback`

本地只观察到一个无关的设备离线 warning，来自一个不可用的源设备，不是本 PR 修复路径导致的错误。

### 不包含的内容

这个 PR **不包含**：

- AC fan-only 派生实体功能
- Sonoff 本地风扇 YAML 配置
- HomeKit/template helper 配置
- translation 调整
- 任何本地设备 ID、账号、IP、token 或 Home Assistant package 配置

AC fan-only 派生实体会单独通过 issue 讨论，避免把明确 bug fix 和设计性功能混在同一个 PR 中。
