### PR TITLE
feat(fan): add AC fan-only entity with normalized fan modes

### DIFF
--- a/custom_components/midea_auto_cloud/climate.py
+++ b/custom_components/midea_auto_cloud/climate.py
@@ -18,6 +18,44 @@ from .midea_entity import MideaEntity
 from .platform_setup import async_setup_platform_entities
 
 
+_NUMERIC_FAN_MODE_TO_SEMANTIC = {
+    "102": "auto",
+    "20": "low",
+    "40": "medium_low",
+    "60": "medium",
+    "80": "high",
+    "100": "max",
+}
+_SEMANTIC_FAN_MODE_TO_NUMERIC = {
+    semantic: numeric for numeric, semantic in _NUMERIC_FAN_MODE_TO_SEMANTIC.items()
+}
+_NUMERIC_FAN_MODE_DISPLAY_ORDER = ["auto", "low", "medium_low", "medium", "high", "max"]
+
+
+def _is_numeric_six_key_fan_mode_mapping(fan_modes) -> bool:
+    if fan_modes is None or not hasattr(fan_modes, "keys"):
+        return False
+    return {str(key) for key in fan_modes.keys()} == set(_NUMERIC_FAN_MODE_TO_SEMANTIC)
+
+
+def _fan_mode_lookup_mapping(fan_modes) -> dict:
+    if not _is_numeric_six_key_fan_mode_mapping(fan_modes):
+        return fan_modes or {}
+    return {
+        _NUMERIC_FAN_MODE_TO_SEMANTIC[str(key)]: value
+        for key, value in fan_modes.items()
+    }
+
+
+def _normalize_fan_mode_input(fan_modes, fan_mode: str) -> str:
+    if not _is_numeric_six_key_fan_mode_mapping(fan_modes):
+        return fan_mode
+    return _NUMERIC_FAN_MODE_TO_SEMANTIC.get(
+        str(fan_mode),
+        fan_mode,
+    )
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -242,10 +280,15 @@ class MideaClimateEntity(MideaEntity, ClimateEntity):
 
     @property
     def fan_modes(self):
+        if _is_numeric_six_key_fan_mode_mapping(self._key_fan_modes):
+            return _NUMERIC_FAN_MODE_DISPLAY_ORDER
         return list(self._key_fan_modes.keys())
 
     @property
     def fan_mode(self):
+        if _is_numeric_six_key_fan_mode_mapping(self._key_fan_modes):
+            selected = self._dict_get_selected(_fan_mode_lookup_mapping(self._key_fan_modes))
+            return selected
         return self._dict_get_selected(self._key_fan_modes)
 
     @property
@@ -334,11 +377,13 @@ class MideaClimateEntity(MideaEntity, ClimateEntity):
         await self.async_set_attributes(new_status)
 
     async def async_set_fan_mode(self, fan_mode: str):
+        fan_mode = _normalize_fan_mode_input(self._key_fan_modes, fan_mode)
+        fan_modes = _fan_mode_lookup_mapping(self._key_fan_modes)
         if self._is_central_ac:
-            fan_speed = self._key_fan_modes.get(fan_mode)
+            fan_speed = fan_modes.get(fan_mode)
             await self.coordinator.async_send_central_ac_control(fan_speed)
         else:
-            new_status = self._key_fan_modes.get(fan_mode)
+            new_status = fan_modes.get(fan_mode)
             await self.async_set_attributes(new_status)
 
     async def async_set_preset_mode(self, preset_mode: str):

--- a/custom_components/midea_auto_cloud/fan.py
+++ b/custom_components/midea_auto_cloud/fan.py
@@ -8,6 +8,90 @@ from .midea_entity import MideaEntity
 from .platform_setup import async_setup_platform_entities
 
 
+_NUMERIC_FAN_MODE_TO_SEMANTIC = {
+    "102": "auto",
+    "20": "low",
+    "40": "medium_low",
+    "60": "medium",
+    "80": "high",
+    "100": "max",
+}
+_SEMANTIC_FAN_MODE_TO_NUMERIC = {
+    "auto": "102",
+    "low": "20",
+    "medium_low": "40",
+    "medium": "60",
+    "high": "80",
+    "max": "100",
+}
+_MANUAL_FAN_MODE_ORDER = ["low", "medium_low", "medium", "high", "max"]
+_SEMANTIC_FAN_MODE_ALIASES = {
+    "silent": "low",
+    "full": "max",
+}
+_FAN_ONLY_ENTITY_KEY = "fan_only_fan"
+
+
+def _fan_mode_key_to_semantic(key) -> str | None:
+    key = str(key)
+    if key in _NUMERIC_FAN_MODE_TO_SEMANTIC:
+        return _NUMERIC_FAN_MODE_TO_SEMANTIC[key]
+    if key in _SEMANTIC_FAN_MODE_TO_NUMERIC:
+        return key
+    return _SEMANTIC_FAN_MODE_ALIASES.get(key)
+
+
+def _build_fan_only_fan_mode_configs(fan_modes) -> dict[str, dict]:
+    if fan_modes is None or not hasattr(fan_modes, "items"):
+        return {}
+
+    mode_configs = {}
+    for key, value in fan_modes.items():
+        semantic_mode = _fan_mode_key_to_semantic(key)
+        if semantic_mode is not None:
+            mode_configs[semantic_mode] = value
+    return mode_configs
+
+
+def _default_manual_fan_mode(manual_fan_modes: list[str]) -> str:
+    if "medium_low" in manual_fan_modes:
+        return "medium_low"
+    if "medium" in manual_fan_modes:
+        return "medium"
+    return manual_fan_modes[0]
+
+
+def _supports_fan_only_derived_fan(config: dict) -> bool:
+    climate_entities = (config.get("entities") or {}).get(Platform.CLIMATE, {}) or {}
+    for climate_config in climate_entities.values():
+        hvac_modes = climate_config.get("hvac_modes") or {}
+        if "fan_only" not in hvac_modes or "off" not in hvac_modes:
+            continue
+        fan_mode_configs = _build_fan_only_fan_mode_configs(climate_config.get("fan_modes"))
+        if "auto" in fan_mode_configs and any(
+            mode in fan_mode_configs for mode in _MANUAL_FAN_MODE_ORDER
+        ):
+            return True
+    return False
+
+
+def _add_fan_only_derived_fan(entities, coordinator, device, manufacturer, rationale, config):
+    if coordinator is None or device is None:
+        return
+    if not _supports_fan_only_derived_fan(config):
+        return
+    entities.append(
+        MideaFanOnlyFanEntity(
+            coordinator,
+            device,
+            manufacturer,
+            rationale,
+            _FAN_ONLY_ENTITY_KEY,
+            config,
+        )
+    )
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -21,7 +105,128 @@ async def async_setup_entry(
         lambda coordinator, device, manufacturer, rationale, entity_key, ecfg: MideaFanEntity(
             coordinator, device, manufacturer, rationale, entity_key, ecfg
         ),
+        per_device_hook=_add_fan_only_derived_fan,
     )
+
+
+class MideaFanOnlyFanEntity(MideaEntity, FanEntity):
+    def __init__(self, coordinator, device, manufacturer, rationale, entity_key, config):
+        climate_entities = (config.get("entities") or {}).get(Platform.CLIMATE, {}) or {}
+        climate_config = next(
+            ecfg for ecfg in climate_entities.values()
+            if _build_fan_only_fan_mode_configs(ecfg.get("fan_modes")).get("auto") is not None
+            and any(
+                mode in _build_fan_only_fan_mode_configs(ecfg.get("fan_modes"))
+                for mode in _MANUAL_FAN_MODE_ORDER
+            )
+            and "fan_only" in (ecfg.get("hvac_modes") or {})
+            and "off" in (ecfg.get("hvac_modes") or {})
+        )
+        super().__init__(
+            coordinator,
+            device.device_id,
+            device.device_name,
+            f"T0x{device.device_type:02X}",
+            device.sn,
+            device.sn8,
+            device.model,
+            entity_key,
+            device=device,
+            manufacturer=manufacturer,
+            rationale=rationale,
+            config={
+                "translation_key": "fan_only_fan",
+            },
+        )
+        self._key_hvac_modes = climate_config.get("hvac_modes")
+        self._fan_mode_configs = _build_fan_only_fan_mode_configs(climate_config.get("fan_modes"))
+        self._manual_fan_modes = [
+            mode for mode in _MANUAL_FAN_MODE_ORDER if mode in self._fan_mode_configs
+        ]
+        self._attr_speed_count = len(self._manual_fan_modes)
+
+    @property
+    def supported_features(self):
+        return (
+            FanEntityFeature.TURN_ON
+            | FanEntityFeature.TURN_OFF
+            | FanEntityFeature.SET_SPEED
+            | FanEntityFeature.PRESET_MODE
+        )
+
+    @property
+    def is_on(self) -> bool:
+        return self._current_hvac_mode() == "fan_only"
+
+    @property
+    def preset_modes(self):
+        return ["auto", "manual"]
+
+    @property
+    def preset_mode(self):
+        if not self.is_on:
+            return None
+        if self._current_fan_mode() == "auto":
+            return "auto"
+        return "manual"
+
+    @property
+    def percentage(self):
+        if not self.is_on:
+            return 0
+        current_fan_mode = self._current_fan_mode()
+        if current_fan_mode not in self._manual_fan_modes:
+            return 0
+        return round(
+            (self._manual_fan_modes.index(current_fan_mode) + 1)
+            * 100
+            / len(self._manual_fan_modes)
+        )
+
+    async def async_turn_on(
+            self,
+            percentage: int | None = None,
+            preset_mode: str | None = None,
+            **kwargs,
+    ):
+        if preset_mode is not None:
+            await self.async_set_preset_mode(preset_mode)
+            return
+        if percentage is not None:
+            await self.async_set_percentage(percentage)
+            return
+        await self._async_set_fan_only_mode(_default_manual_fan_mode(self._manual_fan_modes))
+
+    async def async_turn_off(self):
+        await self.async_set_attributes(self._key_hvac_modes["off"])
+
+    async def async_set_percentage(self, percentage: int):
+        if percentage <= 0:
+            await self.async_turn_off()
+            return
+        selected_index = round(percentage * len(self._manual_fan_modes) / 100) - 1
+        selected_index = max(0, min(selected_index, len(self._manual_fan_modes) - 1))
+        await self._async_set_fan_only_mode(self._manual_fan_modes[selected_index])
+
+    async def async_set_preset_mode(self, preset_mode: str):
+        if preset_mode == "auto":
+            await self._async_set_fan_only_mode("auto")
+            return
+        if preset_mode == "manual":
+            await self._async_set_fan_only_mode(_default_manual_fan_mode(self._manual_fan_modes))
+
+    def _current_hvac_mode(self):
+        return self._dict_get_selected(self._key_hvac_modes)
+
+    def _current_fan_mode(self):
+        selected = self._dict_get_selected(self._fan_mode_configs)
+        return selected
+
+    async def _async_set_fan_only_mode(self, fan_mode: str):
+        new_status = {}
+        new_status.update(self._key_hvac_modes["fan_only"])
+        new_status.update(self._fan_mode_configs[fan_mode])
+        await self.async_set_attributes(new_status)
 
 
 class MideaFanEntity(MideaEntity, FanEntity):
@@ -141,7 +346,9 @@ class MideaFanEntity(MideaEntity, FanEntity):
         new_status = {}
         if preset_mode is not None and self._key_preset_modes is not None:
             mode_config = self._key_preset_modes.get(preset_mode, {})
-            new_status.update = mode_config
+            new_status.update(
+                {key: value for key, value in mode_config.items() if key != "speeds"}
+            )
         
             # 切换到该模式的档位配置
             if "speeds" in mode_config:
@@ -229,7 +436,7 @@ class MideaFanEntity(MideaEntity, FanEntity):
             self._current_preset_mode = preset_mode
         
             # 设置模式
-            new_status = mode_config
+            new_status = {key: value for key, value in mode_config.items() if key != "speeds"}
         
             # 如果只有一个档位，自动设置
             if "speeds" in mode_config and len(mode_config["speeds"]) == 1:

--- a/custom_components/midea_auto_cloud/fan.py
+++ b/custom_components/midea_auto_cloud/fan.py
@@ -160,7 +160,7 @@ class MideaFanOnlyFanEntity(MideaEntity, FanEntity):
 
     @property
     def preset_modes(self):
-        return ["auto", "manual"]
+        return ["auto"]
 
     @property
     def preset_mode(self):
@@ -168,7 +168,7 @@ class MideaFanOnlyFanEntity(MideaEntity, FanEntity):
             return None
         if self._current_fan_mode() == "auto":
             return "auto"
-        return "manual"
+        return None
 
     @property
     def percentage(self):
@@ -212,8 +212,6 @@ class MideaFanOnlyFanEntity(MideaEntity, FanEntity):
         if preset_mode == "auto":
             await self._async_set_fan_only_mode("auto")
             return
-        if preset_mode == "manual":
-            await self._async_set_fan_only_mode(_default_manual_fan_mode(self._manual_fan_modes))
 
     def _current_hvac_mode(self):
         return self._dict_get_selected(self._key_hvac_modes)

--- a/custom_components/midea_auto_cloud/translations/en.json
+++ b/custom_components/midea_auto_cloud/translations/en.json
@@ -334,7 +334,7 @@
       "standby_status": {
         "name": "Standby Status"
       },
-	  "out_water": {
+      "out_water": {
         "name": "Out Water"
       },
       "out_hot_water": {
@@ -393,8 +393,7 @@
               "vertical_only": "Vertical Swing"
             }
           }
-        }
-        ,
+        },
         "state": {
           "off": "off",
           "auto": "auto"
@@ -610,7 +609,7 @@
       "dry_step_switch": {
         "name": "Dry Step Switch",
         "state": {
-           "cancel": "Cancel",
+          "cancel": "Cancel",
           "waiting": "Standby",
           "running": "Running"
         }
@@ -719,19 +718,19 @@
           "300": "300s"
         }
       },
-		"fresh_air_mode_select": {
-		    "name": "Mode",
-		    "state": {
-		        "normal": "Normal",
-		        "smart": "Smart",
-		        "manual_recirculation": "Manual Recirculation",
-		        "auto_recirculation": "Auto Recirculation",
-		        "supply_air_gentle": "Gentle Supply Air",
-		        "supply_air_fast": "Fast Supply Air",
-		        "exhaust_air_gentle": "Gentle Exhaust Air",
-		        "exhaust_air_fast": "Fast Exhaust Air"
-		    }
-		},
+      "fresh_air_mode_select": {
+        "name": "Mode",
+        "state": {
+          "normal": "Normal",
+          "smart": "Smart",
+          "manual_recirculation": "Manual Recirculation",
+          "auto_recirculation": "Auto Recirculation",
+          "supply_air_gentle": "Gentle Supply Air",
+          "supply_air_fast": "Fast Supply Air",
+          "exhaust_air_gentle": "Gentle Exhaust Air",
+          "exhaust_air_fast": "Fast Exhaust Air"
+        }
+      },
       "dehydration_speed": {
         "name": "Dehydration Speed"
       },
@@ -1409,7 +1408,7 @@
           "5": "High"
         }
       },
-	  "clean_interval": {
+      "clean_interval": {
         "name": "Clean Interval",
         "state": {
           "0": "OFF",
@@ -1473,7 +1472,7 @@
       "fresh_filter_time": {
         "name": "Filter remaining life"
       },
-     "tips_code": {
+      "tips_code": {
         "name": "Tips Code"
       },
       "version": {
@@ -1554,7 +1553,7 @@
       },
       "b7_left_status": {
         "name": "Left Stove Status",
-          "state": {
+        "state": {
           "initial": "Initial",
           "power_off": "Power Off",
           "working": "Working",
@@ -1566,7 +1565,7 @@
       },
       "b7_right_status": {
         "name": "Right Stove Status",
-          "state": {
+        "state": {
           "initial": "Initial",
           "power_off": "Power Off",
           "working": "Working",
@@ -2164,7 +2163,7 @@
       "end_time_minute": {
         "name": "End Time Minute"
       },
-	  "end_time": {
+      "end_time": {
         "name": "Heat End Time"
       },
       "flow": {
@@ -2428,7 +2427,7 @@
       "life_2": {
         "name": "MPC Filter Cartridge Lifespan"
       },
-	  "life_2_pcb": {
+      "life_2_pcb": {
         "name": "Life2_PCB"
       },
       "water_consumption": {
@@ -2575,7 +2574,7 @@
       "total_elec_value": {
         "name": "Total Electricity"
       },
-	  "clean_water_consumption_next_remaining": {
+      "clean_water_consumption_next_remaining": {
         "name": "Clean Water Consumption Next Remaining"
       },
       "clean_interval_next_days_remaining": {
@@ -2628,10 +2627,10 @@
         "name": "Lightness"
       },
       "custom_timing": {
-        "name": "Light Off Timer" 
+        "name": "Light Off Timer"
       },
       "radar_induction_closing_time": {
-        "name": "Night Light Timer" 
+        "name": "Night Light Timer"
       },
       "keep_warm_time": {
         "name": "Keep Warm Time"
@@ -2720,7 +2719,7 @@
       "rinse_level": {
         "name": "Rinse Level"
       },
-	  "clean_water_consumption": {
+      "clean_water_consumption": {
         "name": "Clean Water Consumption"
       },
       "quantify_21": {
@@ -2785,21 +2784,32 @@
             }
           }
         }
+      },
+      "fan_only_fan": {
+        "name": "Fan only",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Auto",
+              "manual": "Manual"
+            }
+          }
+        }
       }
     },
-  "switch": {
-    "efficient": {
+    "switch": {
+      "efficient": {
         "name": "Low Power Insulation"
       },
-	  "prevent_super_cool": {
+      "prevent_super_cool": {
         "name": "Prevent Super Cool"
       },
-		"new_wind_machine": {
-			"name": "Fresh air switch"
-		},
-		"anion_status": {
-			"name": "Sterilization"
-		},
+      "new_wind_machine": {
+        "name": "Fresh air switch"
+      },
+      "anion_status": {
+        "name": "Sterilization"
+      },
       "radar_induction_enable": {
         "name": "Radar Induction"
       },
@@ -2929,7 +2939,7 @@
       "hot_power": {
         "name": "Hot Power"
       },
-	  "heat_function": {
+      "heat_function": {
         "name": "Heat Function"
       },
       "midea_manager": {
@@ -3775,7 +3785,7 @@
       "forcetbh_state": {
         "name": "Force Standby"
       },
-	  "manul_humi": {
+      "manul_humi": {
         "name": "humidification"
       },
       "manul_humi_value": {
@@ -3820,7 +3830,7 @@
       "auto_eco": {
         "name": "Auto Eco"
       },
-	  "open_close_switch": {
+      "open_close_switch": {
         "name": "Open Close Switch"
       },
       "start_clean": {
@@ -3869,8 +3879,8 @@
         "name": "Sleep 5"
       }
     },
-  "vacuum": {
     "vacuum": {
+      "vacuum": {
         "name": "Robotic Vacuum",
         "state_attributes": {
           "fan_speed": {

--- a/custom_components/midea_auto_cloud/translations/zh-Hans.json
+++ b/custom_components/midea_auto_cloud/translations/zh-Hans.json
@@ -400,7 +400,9 @@
               "auto": "自动",
               "low": "低速",
               "medium": "中速",
-              "high": "高速"
+              "high": "高速",
+              "medium_low": "中低速",
+              "max": "最高速"
             }
           },
           "swing_mode": {
@@ -413,8 +415,7 @@
               "vertical_only": "上下摆风"
             }
           }
-        }
-        ,
+        },
         "state": {
           "off": "关闭",
           "auto": "自动"
@@ -439,7 +440,9 @@
               "auto": "自动",
               "low": "低速",
               "medium": "中速",
-              "high": "高速"
+              "high": "高速",
+              "medium_low": "中低速",
+              "max": "最高速"
             }
           }
         }
@@ -463,7 +466,9 @@
               "auto": "自动",
               "low": "低速",
               "medium": "中速",
-              "high": "高速"
+              "high": "高速",
+              "medium_low": "中低速",
+              "max": "最高速"
             }
           }
         }
@@ -487,7 +492,9 @@
               "auto": "自动",
               "low": "低速",
               "medium": "中速",
-              "high": "高速"
+              "high": "高速",
+              "medium_low": "中低速",
+              "max": "最高速"
             }
           }
         }
@@ -511,7 +518,9 @@
               "auto": "自动",
               "low": "低速",
               "medium": "中速",
-              "high": "高速"
+              "high": "高速",
+              "medium_low": "中低速",
+              "max": "最高速"
             }
           }
         }
@@ -535,7 +544,9 @@
               "auto": "自动",
               "low": "低速",
               "medium": "中速",
-              "high": "高速"
+              "high": "高速",
+              "medium_low": "中低速",
+              "max": "最高速"
             }
           }
         }
@@ -556,7 +567,9 @@
               "medium": "中速",
               "high": "高速",
               "full": "强劲",
-              "auto": "自动风"
+              "auto": "自动风",
+              "medium_low": "中低速",
+              "max": "最高速"
             }
           },
           "preset_modes": {
@@ -601,12 +614,12 @@
         "name": "加湿器",
         "state_attributes": {
           "mode": {
-              "state": {
-                  "auto": "AI湿随温变",
-                  "manual": "手动",
-                  "moist_skin": "润肤",
-                  "sleep": "睡眠"
-              }
+            "state": {
+              "auto": "AI湿随温变",
+              "manual": "手动",
+              "moist_skin": "润肤",
+              "sleep": "睡眠"
+            }
           }
         }
       },
@@ -753,19 +766,19 @@
           "300": "300秒"
         }
       },
-		"fresh_air_mode_select": {
+      "fresh_air_mode_select": {
         "name": "模式",
         "state": {
-			  "normal": "普通",
-		  	"smart": "智能",
-			  "manual_recirculation": "手动内循环",
-			  "auto_recirculation": "自动内循环",
-			  "supply_air_gentle": "舒缓进风",
-			  "supply_air_fast": "快速进风",
-			  "exhaust_air_gentle": "舒缓排风",
-			  "exhaust_air_fast": "快速排风"
+          "normal": "普通",
+          "smart": "智能",
+          "manual_recirculation": "手动内循环",
+          "auto_recirculation": "自动内循环",
+          "supply_air_gentle": "舒缓进风",
+          "supply_air_fast": "快速进风",
+          "exhaust_air_gentle": "舒缓排风",
+          "exhaust_air_fast": "快速排风"
         }
-    },
+      },
       "dehydration_speed": {
         "name": "转速"
       },
@@ -883,10 +896,10 @@
       "bright_led": {
         "name": "亮度LED",
         "state": {
-            "light": "亮",
-            "dark": "暗",
-            "exit": "熄灭"
-          }
+          "light": "亮",
+          "dark": "暗",
+          "exit": "熄灭"
+        }
       },
       "capacity": {
         "name": "容量"
@@ -1079,7 +1092,7 @@
       },
       "gesture_sensitivity_value": {
         "name": "手势灵敏度",
-          "state": {
+        "state": {
           "low": "低",
           "medium": "中",
           "high": "高"
@@ -1432,7 +1445,7 @@
           "resume": "继续",
           "charge": "开始回充",
           "charge_pause": "回充暂停",
-          "charge_continue":  "继续回充",
+          "charge_continue": "继续回充",
           "auto_clean": "自动清扫",
           "auto_clean_pause": "清扫暂停",
           "auto_clean_continue": "继续清扫",
@@ -1501,7 +1514,7 @@
       "gear": {
         "name": "档位",
         "state": {
-          "off":"关闭",
+          "off": "关闭",
           "low": "低",
           "medium": "中",
           "high": "高",
@@ -2940,7 +2953,7 @@
       "hosting_lower": {
         "name": "PM2.5下阈值(停止净化)"
       },
-	    "fresh_air_fan_speed": {
+      "fresh_air_fan_speed": {
         "name": "风量"
       },
       "steam_quantity": {
@@ -2959,10 +2972,10 @@
         "name": "照明亮度"
       },
       "custom_timing": {
-        "name": "延时关灯" 
+        "name": "延时关灯"
       },
       "radar_induction_closing_time": {
-        "name": "夜灯延时关闭" 
+        "name": "夜灯延时关闭"
       },
       "keep_warm_time": {
         "name": "保温时间"
@@ -3125,19 +3138,30 @@
             }
           }
         }
+      },
+      "fan_only_fan": {
+        "name": "送风",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "自动",
+              "manual": "手动"
+            }
+          }
+        }
       }
     },
     "switch": {
-    "efficient": {
+      "efficient": {
         "name": "低耗保温"
       },
-	  "prevent_super_cool": {
+      "prevent_super_cool": {
         "name": "智控温"
       },
-	  "new_wind_machine": {
+      "new_wind_machine": {
         "name": "新风开关"
       },
-	  "anion_status": {
+      "anion_status": {
         "name": "除菌"
       },
       "radar_induction_enable": {
@@ -4121,7 +4145,7 @@
       "forcetbh_state": {
         "name": "强制待机"
       },
-	  "manul_humi": {
+      "manul_humi": {
         "name": "加湿"
       },
       "manul_humi_value": {


### PR DESCRIPTION
# PR 草稿：规范空调风速模式并增加 fan_only 派生风扇实体

## 标题

feat(fan): add AC fan-only entity with normalized fan modes

## 正文

### 这个 PR 改了什么

这个 PR 解决两个相关问题：

1. **规范 climate 实体的风速模式显示和调用**
   - 对使用 `20`、`40`、`60`、`80`、`100`、`102` 作为底层风速值的空调，将 HA 暴露出来的 fan modes 规范为：
     - `auto`
     - `low`
     - `medium_low`
     - `medium`
     - `high`
     - `max`
   - 底层仍然发送原设备协议值，例如 `medium_low` 仍映射到 `wind_speed: 40`。
   - 保持向后兼容：旧的 `fan_mode="40"` 调用会被归一化为 `medium_low` 并继续生效。

2. **增加 AC fan_only 派生 FanEntity**
   - 对明确支持 `hvac_modes.fan_only`、`hvac_modes.off`、`fan_modes.auto` 和手动风速档位的空调，额外生成一个 `fan_only_fan` 实体。
   - 该实体只在底层 climate 处于 `fan_only` 时显示为 `on`。
   - 支持 `auto/manual` preset。
   - 支持百分比风速控制，并映射到底层离散风速档位。

同时修复 `MideaFanEntity.async_turn_on(preset_mode=...)` 中 `new_status.update = mode_config` 的 bug，避免 preset turn_on 时尝试覆盖 `dict.update` 方法。

### 为什么需要这个修改

#### 1. HomeKit 不支持 climate 的 fan_only 模式

Home Assistant 的 climate 实体可以表达 `fan_only`，但 HomeKit 的 thermostat/climate 模型没有对应的“仅送风”模式。结果是：即使设备本身支持仅送风，映射到 HomeKit 后也没有合适的 thermostat 模式来控制它。

把 `fan_only` 独立成一个 `fan` 实体后，HomeKit 可以把它当成真正的风扇来控制，这比把“仅送风”塞进 thermostat 语义里更合理。

#### 2. 数值风速不是正式用户语义

部分空调 mapping 使用 `20/40/60/80/100/102` 作为风速和自动模式。这些值更像设备协议编码，不适合直接暴露给 HA 用户，也不适合 HomeKit fan modes。

这个 PR 把它们映射为正式档位：

- `20` → `low`
- `40` → `medium_low`
- `60` → `medium`
- `80` → `high`
- `100` → `max`
- `102` → `auto`

这样 HA 和 HomeKit 都可以得到更稳定、更正式的风扇模式表达。

### 安全边界

- 只有满足能力条件的 climate mapping 才会生成 `fan_only_fan`。
- 不支持 `fan_only` 的设备不会新增实体。
- 已有新风/鲜风等 `Platform.FAN` mapping 不会被替换。
- 底层协议值仍保持不变，只调整 HA 暴露出的用户语义和派生 fan 控制入口。

### 本地验证

本地 Home Assistant 验证通过：

- 多个 Midea AC 成功生成 `fan_only_fan` 实体。
- 目标 `fan_only_fan` 实体支持 `preset_modes=["auto", "manual"]`。
- 手动档位映射为 5 档百分比控制。
- 所有目标实体测试后均回到 `off`。
- climate 实体仍接受旧数字调用，例如 `fan_mode="40"`，并归一化为 `medium_low`。
- HA 配置检查通过。
- 测试后未发现 `custom_components.midea_auto_cloud.fan`、`fan_only` 或 traceback 相关错误。

### 不包含的内容

- 不包含任何本地 Sonoff 配置。
- 不包含 HomeKit/template helper 本地 YAML。
- 不包含本地设备 ID、账号、IP、token 或 Home Assistant package 配置。
