### PR TITLE
feat: add F5022-WB7 water heater mapping

### DIFF
--- a/custom_components/midea_auto_cloud/device_mapping/T0xE2.py
+++ b/custom_components/midea_auto_cloud/device_mapping/T0xE2.py
@@ -1,4 +1,4 @@
-from homeassistant.const import Platform, UnitOfTemperature, UnitOfTime, PRECISION_WHOLE
+from homeassistant.const import Platform, UnitOfTemperature, UnitOfTime, PERCENTAGE, PRECISION_WHOLE
 from homeassistant.components.sensor import SensorStateClass, SensorDeviceClass
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.switch import SwitchDeviceClass
@@ -201,6 +201,129 @@ DEVICE_MAPPING = {
                 },
                 "elec_warning": {
                     "device_class": BinarySensorDeviceClass.PROBLEM,
+                }
+            }
+        }
+    },
+    "510214FN": {
+        "manufacturer": "美的",
+        "rationale": ["off", "on"],
+        "queries": [{}],
+        "centralized": [],
+        "calculate": {
+            "get": [
+                {
+                    "lvalue": "[end_time]",
+                    "rvalue": "[end_time_hour] * 60 + [end_time_minute]"
+                }
+            ],
+            "set": {
+            }
+        },
+        "entities": {
+            Platform.CLIMATE: {
+                "water_heater": {
+                    "power": "power",
+                    "hvac_modes": {
+                        "off": {"power": "off"},
+                        "heat": {"power": "on"},
+                    },
+                    "target_temperature": "temperature",
+                    "current_temperature": "cur_temperature",
+                    "min_temp": 30,
+                    "max_temp": 75,
+                    "temperature_unit": UnitOfTemperature.CELSIUS,
+                    "precision": PRECISION_WHOLE
+                }
+            },
+            Platform.SELECT: {
+                "heat": {
+                    "options": {
+                        "half": {"half_heat": "on", "whole_heat": "off"},
+                        "whole": {"half_heat": "off", "whole_heat": "on"}
+                    },
+                    "translation_key": "heating_capacity"
+                }
+            },
+            Platform.SWITCH: {
+                "power": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "eplus": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                    "translation_key": "e_capacity"
+                },
+                "efficient": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                    "translation_key": "low_energy_save"
+                },
+                "night": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                    "translation_key": "night_electricity_cloud"
+                },
+                "sterilization": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                    "translation_key": "sterilize_high_temp"
+                }
+            },
+            Platform.SENSOR: {
+                "cur_temperature": {
+                    "device_class": SensorDeviceClass.TEMPERATURE,
+                    "unit_of_measurement": UnitOfTemperature.CELSIUS,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                    "translation_key": "current_water_temperature"
+                },
+                "temperature": {
+                    "device_class": SensorDeviceClass.TEMPERATURE,
+                    "unit_of_measurement": UnitOfTemperature.CELSIUS,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                    "translation_key": "target_water_temperature"
+                },
+                "heat_water_level": {
+                    "unit_of_measurement": PERCENTAGE,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                    "translation_key": "hot_water_amount"
+                },
+                "end_time": {
+                    "device_class": SensorDeviceClass.DURATION,
+                    "unit_of_measurement": UnitOfTime.MINUTES,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                    "translation_key": "heating_remaining_time"
+                },
+                "water_quality": {
+                    "state_class": SensorStateClass.MEASUREMENT,
+                    "translation_key": "water_quality_score"
+                },
+                "in_temperature": {
+                    "device_class": SensorDeviceClass.TEMPERATURE,
+                    "unit_of_measurement": UnitOfTemperature.CELSIUS,
+                    "state_class": SensorStateClass.MEASUREMENT
+                },
+                "error_code": {
+                    "device_class": SensorDeviceClass.ENUM,
+                    "translation_key": "fault_code"
+                }
+            },
+            Platform.BINARY_SENSOR: {
+                "communication_error": {
+                    "device_class": BinarySensorDeviceClass.PROBLEM,
+                    "translation_key": "communication_exception"
+                },
+                "sensor_error": {
+                    "device_class": BinarySensorDeviceClass.PROBLEM,
+                    "translation_key": "sensor_exception"
+                },
+                "limit_error": {
+                    "device_class": BinarySensorDeviceClass.PROBLEM,
+                    "translation_key": "limit_exception"
+                },
+                "ele_exception": {
+                    "device_class": BinarySensorDeviceClass.PROBLEM,
+                    "translation_key": "mains_power_exception"
+                },
+                "elec_warning": {
+                    "device_class": BinarySensorDeviceClass.PROBLEM,
+                    "translation_key": "electrical_warning"
                 }
             }
         }

--- a/custom_components/midea_auto_cloud/translations/en.json
+++ b/custom_components/midea_auto_cloud/translations/en.json
@@ -268,20 +268,35 @@
       "communication_error": {
         "name": "Communication Error"
       },
+      "communication_exception": {
+        "name": "Communication Exception"
+      },
       "door_status": {
         "name": "Door Status"
       },
       "ele_exception": {
         "name": "Ele Exception"
       },
+      "mains_power_exception": {
+        "name": "Mains Power Exception"
+      },
       "elec_warning": {
         "name": "Elec Warning"
+      },
+      "electrical_warning": {
+        "name": "Electrical Warning"
       },
       "limit_error": {
         "name": "Limit Error"
       },
+      "limit_exception": {
+        "name": "Limit Exception"
+      },
       "sensor_error": {
         "name": "Sensor Error"
+      },
+      "sensor_exception": {
+        "name": "Sensor Exception"
       },
       "lock": {
         "name": "Lock"
@@ -584,6 +599,13 @@
       }
     },
     "select": {
+      "heating_capacity": {
+        "name": "Heating Tank",
+        "state": {
+          "half": "Half Tank Heat",
+          "whole": "Whole Tank Heat"
+        }
+      },
       "aidry": {
         "name": "Aidry"
       },
@@ -1453,6 +1475,24 @@
       }
     },
     "sensor": {
+      "current_water_temperature": {
+        "name": "Current Water Temperature"
+      },
+      "target_water_temperature": {
+        "name": "Target Water Temperature"
+      },
+      "hot_water_amount": {
+        "name": "Hot Water Amount"
+      },
+      "heating_remaining_time": {
+        "name": "Heating Remaining Time"
+      },
+      "water_quality_score": {
+        "name": "Water Quality Score"
+      },
+      "fault_code": {
+        "name": "Fault Code"
+      },
       "wash_stage": {
         "name": "Washing Stage",
         "state": {
@@ -2830,6 +2870,9 @@
       "efficient": {
         "name": "Low Power Insulation"
       },
+      "low_energy_save": {
+        "name": "Low Energy Save"
+      },
       "prevent_super_cool": {
         "name": "Prevent Super Cool"
       },
@@ -2956,6 +2999,9 @@
       "eplus": {
         "name": "Eplus"
       },
+      "e_capacity": {
+        "name": "E+ Capacity"
+      },
       "fast_hot_power": {
         "name": "Fast Hot Power"
       },
@@ -3000,6 +3046,9 @@
       },
       "night": {
         "name": "Night"
+      },
+      "night_electricity_cloud": {
+        "name": "Off-Peak Night Heating"
       },
       "now_wash": {
         "name": "Now Wash"

--- a/custom_components/midea_auto_cloud/translations/zh-Hans.json
+++ b/custom_components/midea_auto_cloud/translations/zh-Hans.json
@@ -288,20 +288,35 @@
       "communication_error": {
         "name": "通信错误"
       },
+      "communication_exception": {
+        "name": "通信异常"
+      },
       "door_status": {
         "name": "门状态"
       },
       "ele_exception": {
         "name": "电气异常"
       },
+      "mains_power_exception": {
+        "name": "市电异常"
+      },
       "elec_warning": {
+        "name": "电气警告"
+      },
+      "electrical_warning": {
         "name": "电气警告"
       },
       "limit_error": {
         "name": "限制错误"
       },
+      "limit_exception": {
+        "name": "限位异常"
+      },
       "sensor_error": {
         "name": "传感器错误"
+      },
+      "sensor_exception": {
+        "name": "传感器异常"
       },
       "lock": {
         "name": "锁定"
@@ -628,6 +643,13 @@
       }
     },
     "select": {
+      "heating_capacity": {
+        "name": "加热胆量",
+        "state": {
+          "half": "半胆加热",
+          "whole": "全胆加热"
+        }
+      },
       "aidry": {
         "name": "智感干洗",
         "state": {
@@ -1728,6 +1750,24 @@
       }
     },
     "sensor": {
+      "current_water_temperature": {
+        "name": "当前水温"
+      },
+      "target_water_temperature": {
+        "name": "设定水温"
+      },
+      "hot_water_amount": {
+        "name": "热水量"
+      },
+      "heating_remaining_time": {
+        "name": "加热剩余时间"
+      },
+      "water_quality_score": {
+        "name": "水质得分"
+      },
+      "fault_code": {
+        "name": "故障代码"
+      },
       "wash_stage": {
         "name": "洗涤阶段",
         "state": {
@@ -3178,6 +3218,9 @@
       "efficient": {
         "name": "低耗保温"
       },
+      "low_energy_save": {
+        "name": "低耗节能"
+      },
       "prevent_super_cool": {
         "name": "智控温"
       },
@@ -3304,6 +3347,9 @@
       "eplus": {
         "name": "大水量"
       },
+      "e_capacity": {
+        "name": "E+增容"
+      },
       "fast_hot_power": {
         "name": "快速加热电源"
       },
@@ -3348,6 +3394,9 @@
       },
       "night": {
         "name": "夜间"
+      },
+      "night_electricity_cloud": {
+        "name": "峰谷夜电"
       },
       "now_wash": {
         "name": "立即洗涤"


### PR DESCRIPTION
## Summary
- add an SN8-specific T0xE2 mapping for 510214FN / F5022-WB7 electric water heaters
- expose the common controls shown by the Midea app plugin: power, heating capacity, E+ capacity, low energy save, off-peak night heating, and high temperature sterilization
- add focused sensors for water temperatures, hot water amount, heating remaining time, water quality score, fault code, and problem binary sensors
- add English and Simplified Chinese translations for the model-specific entity names

## Device context
- Device type: T0xE2
- SN8: 510214FN
- Model observed in Home Assistant: F5022-WB7(HE)
- Lua protocol file observed locally: T_0000_E2_24.lua
- Midea app plugin config lists this SN8 with funcList: cloudHome4, bathReport, lowEnergySave, highTempSterilize2, eCapacity, waterQuality, securitGuard, nightElectricityCloud

## Validation
- tested locally in Home Assistant with a real F5022-WB7(HE) device
- verified entity creation and live state updates after restart
- ran python py_compile for T0xE2.py
- ran python -m json.tool for en.json and zh-Hans.json
- ran git diff --check