### PR TITLE
完善除湿机(T0xA1)设备映射，新增净化实体和状态传感器

### DIFF
--- a/custom_components/midea_auto_cloud/device_mapping/T0xA1.py
+++ b/custom_components/midea_auto_cloud/device_mapping/T0xA1.py
@@ -1,8 +1,8 @@
 from homeassistant.components.humidifier import HumidifierDeviceClass
-from homeassistant.const import Platform, UnitOfTime
 from homeassistant.components.sensor import SensorStateClass, SensorDeviceClass
-from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.switch import SwitchDeviceClass
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.const import Platform, UnitOfTime
 
 DEVICE_MAPPING = {
     "default": {
@@ -25,7 +25,22 @@ DEVICE_MAPPING = {
                 },
                 "filter_tip": {
                     "device_class": SwitchDeviceClass.SWITCH,
-                    "rationale": [0, 1]
+                    "rationale": [0, 1],
+                },
+                "purifier": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "dry": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "light": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "buzzer": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "self_clean": {
+                    "device_class": SwitchDeviceClass.SWITCH,
                 },
             },
             Platform.HUMIDIFIER: {
@@ -34,59 +49,75 @@ DEVICE_MAPPING = {
                     "power": "power",
                     "target_humidity": "humidity",
                     "current_humidity": "cur_humidity",
+                    "mode": "mode",
                     "min_humidity": 35,
                     "max_humidity": 85,
-                    "mode": "mode",
                     "modes": {
                         "continuity": {"mode": "continuity"},
                         "auto": {"mode": "auto"},
                         "fan": {"mode": "fan"},
                         "dry_shoes": {"mode": "dry_shoes"},
-                        "dry_clothes": {"mode": "dry_clothes"}
-                    }
-                }
+                        "dry_clothes": {"mode": "dry_clothes"},
+                    },
+                },
             },
             Platform.BINARY_SENSOR: {
                 "tank_status": {
-                    "device_class": BinarySensorDeviceClass.PROBLEM
-                }
+                    "device_class": BinarySensorDeviceClass.PROBLEM,
+                },
+                "filter_value": {
+                    "device_class": BinarySensorDeviceClass.PROBLEM,
+                },
+                "water_pump": {
+                    "device_class": BinarySensorDeviceClass.RUNNING,
+                },
+                "water_pump_enable": {
+                },
             },
             Platform.SELECT: {
                 "wind_speed": {
                     "options": {
-                        "low": {"wind_speed": "30"},
-                        "high": {"wind_speed": "80"},
-                    }
+                        "silent": {"wind_speed": "20"},
+                        "comfortable": {"wind_speed": "40"},
+                        "high": {"wind_speed": "60"},
+                        "turbo": {"wind_speed": "80"},
+                    },
                 },
                 "power_on_time": {
-                     "options": {
-                        "off": {"power_on_timer": "off"},
-                        "15": {"power_on_timer": "on", "power_on_time_value": "15"},
-                        "30": {"power_on_timer": "on", "power_on_time_value": "30"},
-                        "45": {"power_on_timer": "on", "power_on_time_value": "45"},
-                        "60": {"power_on_timer": "on", "power_on_time_value": "60"},
-                    }
+                    "options": {
+                        "off": {"power_on_timer": "off", "power_on_time_value": 0},
+                        "15": {"power_on_timer": "on", "power_on_time_value": 1},
+                        "30": {"power_on_timer": "on", "power_on_time_value": 2},
+                        "45": {"power_on_timer": "on", "power_on_time_value": 3},
+                        "60": {"power_on_timer": "on", "power_on_time_value": 4},
+                    },
                 },
                 "power_off_time": {
                     "options": {
-                        "off": {"power_off_timer": "off"},
-                        "15": {"power_off_timer": "on", "power_off_time_value": "15"},
-                        "30": {"power_off_timer": "on", "power_off_time_value": "30"},
-                        "45": {"power_off_timer": "on", "power_off_time_value": "45"},
-                        "60": {"power_off_timer": "on", "power_off_time_value": "60"},
-                    }
+                        "off": {"power_off_timer": "off", "power_off_time_value": 0},
+                        "15": {"power_off_timer": "on", "power_off_time_value": 1},
+                        "30": {"power_off_timer": "on", "power_off_time_value": 2},
+                        "45": {"power_off_timer": "on", "power_off_time_value": 3},
+                        "60": {"power_off_timer": "on", "power_off_time_value": 4},
+                    },
                 },
             },
             Platform.SENSOR: {
                 "water_full_time": {
                     "device_class": SensorDeviceClass.DURATION,
                     "unit_of_measurement": UnitOfTime.MINUTES,
-                    "state_class": SensorStateClass.MEASUREMENT
+                    "state_class": SensorStateClass.MEASUREMENT,
                 },
                 "water_full_level": {
-                    "device_class": SensorDeviceClass.ENUM
+                    "device_class": SensorDeviceClass.ENUM,
                 },
-            }
-        }
-    }
+                "error_code": {
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+                "version": {
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+            },
+        },
+    },
 }


### PR DESCRIPTION
## 概述

完善除湿机（T0xA1）的设备映射文件，将设备实际支持但未映射的属性全部加入，使 Home Assistant 可以完整控制除湿机的各项功能。

## 新增实体

### 开关 (Switch)
- **净化开关** (`purifier`) — 除湿机的空气净化功能
- **干燥开关** (`dry`) — 干燥模式
- **屏显开关** (`light`) — 控制显示屏/面板灯
- **声音开关** (`buzzer`) — 控制蜂鸣提示音
- **自清洁开关** (`self_clean`) — 自清洁功能

### 二进制传感器 (Binary Sensor)
- **滤网状态** (`filter_value`) — 滤网是否需要更换
- **水泵运行状态** (`water_pump`) — 水泵是否正在运行
- **水泵启用状态** (`water_pump_enable`) — 水泵功能是否已启用

### 传感器 (Sensor)
- **错误码** (`error_code`) — 设备错误码
- **固件版本** (`version`) — 设备固件版本号

## 修改内容

### 风速档位
从原来的 2 档（低/高）扩展为 4 档：静音(20)、舒适(40)、高速(60)、强劲(80)，与美的标准风速值一致。

### 修复
- 修正开机/关机定时器的 `power_on_time_value`/`power_off_time_value` 值映射格式

## 测试

已在美的除湿机（设备类型 T0xA1，subtype 4）上实际测试验证，所有新增实体均正常显示和控制。