### PR TITLE
完善除湿机(T0xA1)设备映射，新增净化、屏显、蜂鸣器等功能实体

### DIFF
--- a/custom_components/midea_auto_cloud/device_mapping/T0xA1.py
+++ b/custom_components/midea_auto_cloud/device_mapping/T0xA1.py
@@ -1,8 +1,8 @@
 from homeassistant.components.humidifier import HumidifierDeviceClass
-from homeassistant.const import Platform, UnitOfTime
 from homeassistant.components.sensor import SensorStateClass, SensorDeviceClass
-from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.switch import SwitchDeviceClass
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.const import Platform, UnitOfTime
 
 DEVICE_MAPPING = {
     "default": {
@@ -25,7 +25,7 @@ DEVICE_MAPPING = {
                 },
                 "filter_tip": {
                     "device_class": SwitchDeviceClass.SWITCH,
-                    "rationale": [0, 1]
+                    "rationale": [0, 1],
                 },
             },
             Platform.HUMIDIFIER: {
@@ -34,38 +34,38 @@ DEVICE_MAPPING = {
                     "power": "power",
                     "target_humidity": "humidity",
                     "current_humidity": "cur_humidity",
+                    "mode": "mode",
                     "min_humidity": 35,
                     "max_humidity": 85,
-                    "mode": "mode",
                     "modes": {
                         "continuity": {"mode": "continuity"},
                         "auto": {"mode": "auto"},
                         "fan": {"mode": "fan"},
                         "dry_shoes": {"mode": "dry_shoes"},
-                        "dry_clothes": {"mode": "dry_clothes"}
-                    }
-                }
+                        "dry_clothes": {"mode": "dry_clothes"},
+                    },
+                },
             },
             Platform.BINARY_SENSOR: {
                 "tank_status": {
-                    "device_class": BinarySensorDeviceClass.PROBLEM
-                }
+                    "device_class": BinarySensorDeviceClass.PROBLEM,
+                },
             },
             Platform.SELECT: {
                 "wind_speed": {
                     "options": {
                         "low": {"wind_speed": "30"},
                         "high": {"wind_speed": "80"},
-                    }
+                    },
                 },
                 "power_on_time": {
-                     "options": {
+                    "options": {
                         "off": {"power_on_timer": "off"},
                         "15": {"power_on_timer": "on", "power_on_time_value": "15"},
                         "30": {"power_on_timer": "on", "power_on_time_value": "30"},
                         "45": {"power_on_timer": "on", "power_on_time_value": "45"},
                         "60": {"power_on_timer": "on", "power_on_time_value": "60"},
-                    }
+                    },
                 },
                 "power_off_time": {
                     "options": {
@@ -74,19 +74,132 @@ DEVICE_MAPPING = {
                         "30": {"power_off_timer": "on", "power_off_time_value": "30"},
                         "45": {"power_off_timer": "on", "power_off_time_value": "45"},
                         "60": {"power_off_timer": "on", "power_off_time_value": "60"},
-                    }
+                    },
                 },
             },
             Platform.SENSOR: {
                 "water_full_time": {
                     "device_class": SensorDeviceClass.DURATION,
                     "unit_of_measurement": UnitOfTime.MINUTES,
-                    "state_class": SensorStateClass.MEASUREMENT
+                    "state_class": SensorStateClass.MEASUREMENT,
                 },
                 "water_full_level": {
-                    "device_class": SensorDeviceClass.ENUM
+                    "device_class": SensorDeviceClass.ENUM,
                 },
-            }
-        }
-    }
+            },
+        },
+    },
+    "20104032": {
+        "rationale": ["off", "on"],
+        "queries": [{}, {"query_type": "light,sound"}],
+        "centralized": [],
+        "entities": {
+            Platform.SWITCH: {
+                "power": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "anion": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "child_lock": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "wind_swing_ud": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "filter_tip": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                    "rationale": [0, 1],
+                },
+                "purifier": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "dry": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "light": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                    "rationale": [0, 1],
+                },
+                "sound": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                    "rationale": [0, 1],
+                },
+            },
+            Platform.HUMIDIFIER: {
+                "dehumidifier": {
+                    "device_class": HumidifierDeviceClass.HUMIDIFIER,
+                    "power": "power",
+                    "target_humidity": "humidity",
+                    "current_humidity": "cur_humidity",
+                    "mode": "mode",
+                    "min_humidity": 35,
+                    "max_humidity": 85,
+                    "modes": {
+                        "set": {"mode": "set"},
+                        "continuity": {"mode": "continuity"},
+                        "eco": {"mode": "eco"},
+                        "dry_clothes": {"mode": "dry_clothes"},
+                    },
+                },
+            },
+            Platform.BINARY_SENSOR: {
+                "tank_status": {
+                    "device_class": BinarySensorDeviceClass.PROBLEM,
+                },
+                "filter_value": {
+                    "device_class": BinarySensorDeviceClass.PROBLEM,
+                },
+                "water_pump": {
+                    "device_class": BinarySensorDeviceClass.RUNNING,
+                },
+                "water_pump_enable": {
+                },
+            },
+            Platform.SELECT: {
+                "wind_speed": {
+                    "options": {
+                        "silent": {"wind_speed": "20"},
+                        "comfortable": {"wind_speed": "60"},
+                        "high": {"wind_speed": "80"},
+                        "turbo": {"wind_speed": "100"},
+                    },
+                },
+                "power_on_time": {
+                    "options": {
+                        "off": {"power_on_timer": "off", "power_on_time_value": 0},
+                        "15": {"power_on_timer": "on", "power_on_time_value": 1},
+                        "30": {"power_on_timer": "on", "power_on_time_value": 2},
+                        "45": {"power_on_timer": "on", "power_on_time_value": 3},
+                        "60": {"power_on_timer": "on", "power_on_time_value": 4},
+                    },
+                },
+                "power_off_time": {
+                    "options": {
+                        "off": {"power_off_timer": "off", "power_off_time_value": 0},
+                        "15": {"power_off_timer": "on", "power_off_time_value": 1},
+                        "30": {"power_off_timer": "on", "power_off_time_value": 2},
+                        "45": {"power_off_timer": "on", "power_off_time_value": 3},
+                        "60": {"power_off_timer": "on", "power_off_time_value": 4},
+                    },
+                },
+            },
+            Platform.SENSOR: {
+                "water_full_time": {
+                    "device_class": SensorDeviceClass.DURATION,
+                    "unit_of_measurement": UnitOfTime.MINUTES,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+                "water_full_level": {
+                    "device_class": SensorDeviceClass.ENUM,
+                },
+                "error_code": {
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+                "version": {
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+            },
+        },
+    },
 }


### PR DESCRIPTION
新增:
- 净化开关(purifier)、干燥开关(dry)、屏显开关(light)、蜂鸣器开关(sound)
- 滤网状态(filter_value)、水泵运行(water_pump)、水泵启用(water_pump_enable)二进制传感器
- 错误码(error_code)和固件版本(version)传感器
- 新增eco节能模式和set设定模式
- 新增light/sound的B1扩展查询以支持屏显和蜂鸣器读写

修改:
- 风速档位从2档扩展为4档(静音20/舒适60/高速80/强劲100)
- 移除设备不支持的auto/fan/dry_shoes/mute/auto_2/sleep模式
- 修复开机/关机定时器值映射格式