### PR TITLE
为除湿机(T0xA1)新增SN8设备专属配置(20104032)

### DIFF
--- a/custom_components/midea_auto_cloud/device_mapping/T0xA1.py
+++ b/custom_components/midea_auto_cloud/device_mapping/T0xA1.py
@@ -25,7 +25,7 @@ DEVICE_MAPPING = {
                 },
                 "filter_tip": {
                     "device_class": SwitchDeviceClass.SWITCH,
-                    "rationale": [0, 1],
+                    "rationale": [0, 1]
                 },
             },
             Platform.HUMIDIFIER: {
@@ -34,38 +34,38 @@ DEVICE_MAPPING = {
                     "power": "power",
                     "target_humidity": "humidity",
                     "current_humidity": "cur_humidity",
-                    "mode": "mode",
                     "min_humidity": 35,
                     "max_humidity": 85,
+                    "mode": "mode",
                     "modes": {
                         "continuity": {"mode": "continuity"},
                         "auto": {"mode": "auto"},
                         "fan": {"mode": "fan"},
                         "dry_shoes": {"mode": "dry_shoes"},
-                        "dry_clothes": {"mode": "dry_clothes"},
-                    },
-                },
+                        "dry_clothes": {"mode": "dry_clothes"}
+                    }
+                }
             },
             Platform.BINARY_SENSOR: {
                 "tank_status": {
-                    "device_class": BinarySensorDeviceClass.PROBLEM,
-                },
+                    "device_class": BinarySensorDeviceClass.PROBLEM
+                }
             },
             Platform.SELECT: {
                 "wind_speed": {
                     "options": {
                         "low": {"wind_speed": "30"},
                         "high": {"wind_speed": "80"},
-                    },
+                    }
                 },
                 "power_on_time": {
-                    "options": {
+                     "options": {
                         "off": {"power_on_timer": "off"},
                         "15": {"power_on_timer": "on", "power_on_time_value": "15"},
                         "30": {"power_on_timer": "on", "power_on_time_value": "30"},
                         "45": {"power_on_timer": "on", "power_on_time_value": "45"},
                         "60": {"power_on_timer": "on", "power_on_time_value": "60"},
-                    },
+                    }
                 },
                 "power_off_time": {
                     "options": {
@@ -74,20 +74,20 @@ DEVICE_MAPPING = {
                         "30": {"power_off_timer": "on", "power_off_time_value": "30"},
                         "45": {"power_off_timer": "on", "power_off_time_value": "45"},
                         "60": {"power_off_timer": "on", "power_off_time_value": "60"},
-                    },
+                    }
                 },
             },
             Platform.SENSOR: {
                 "water_full_time": {
                     "device_class": SensorDeviceClass.DURATION,
                     "unit_of_measurement": UnitOfTime.MINUTES,
-                    "state_class": SensorStateClass.MEASUREMENT,
+                    "state_class": SensorStateClass.MEASUREMENT
                 },
                 "water_full_level": {
-                    "device_class": SensorDeviceClass.ENUM,
+                    "device_class": SensorDeviceClass.ENUM
                 },
-            },
-        },
+            }
+        }
     },
     "20104032": {
         "rationale": ["off", "on"],

--- a/custom_components/midea_auto_cloud/device_mapping/T0xA1.py
+++ b/custom_components/midea_auto_cloud/device_mapping/T0xA1.py
@@ -1,8 +1,8 @@
 from homeassistant.components.humidifier import HumidifierDeviceClass
-from homeassistant.const import Platform, UnitOfTime
 from homeassistant.components.sensor import SensorStateClass, SensorDeviceClass
-from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.switch import SwitchDeviceClass
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.const import Platform, UnitOfTime
 
 DEVICE_MAPPING = {
     "default": {
@@ -25,7 +25,7 @@ DEVICE_MAPPING = {
                 },
                 "filter_tip": {
                     "device_class": SwitchDeviceClass.SWITCH,
-                    "rationale": [0, 1]
+                    "rationale": [0, 1],
                 },
             },
             Platform.HUMIDIFIER: {
@@ -34,38 +34,38 @@ DEVICE_MAPPING = {
                     "power": "power",
                     "target_humidity": "humidity",
                     "current_humidity": "cur_humidity",
+                    "mode": "mode",
                     "min_humidity": 35,
                     "max_humidity": 85,
-                    "mode": "mode",
                     "modes": {
                         "continuity": {"mode": "continuity"},
                         "auto": {"mode": "auto"},
                         "fan": {"mode": "fan"},
                         "dry_shoes": {"mode": "dry_shoes"},
-                        "dry_clothes": {"mode": "dry_clothes"}
-                    }
-                }
+                        "dry_clothes": {"mode": "dry_clothes"},
+                    },
+                },
             },
             Platform.BINARY_SENSOR: {
                 "tank_status": {
-                    "device_class": BinarySensorDeviceClass.PROBLEM
-                }
+                    "device_class": BinarySensorDeviceClass.PROBLEM,
+                },
             },
             Platform.SELECT: {
                 "wind_speed": {
                     "options": {
                         "low": {"wind_speed": "30"},
                         "high": {"wind_speed": "80"},
-                    }
+                    },
                 },
                 "power_on_time": {
-                     "options": {
+                    "options": {
                         "off": {"power_on_timer": "off"},
                         "15": {"power_on_timer": "on", "power_on_time_value": "15"},
                         "30": {"power_on_timer": "on", "power_on_time_value": "30"},
                         "45": {"power_on_timer": "on", "power_on_time_value": "45"},
                         "60": {"power_on_timer": "on", "power_on_time_value": "60"},
-                    }
+                    },
                 },
                 "power_off_time": {
                     "options": {
@@ -74,19 +74,132 @@ DEVICE_MAPPING = {
                         "30": {"power_off_timer": "on", "power_off_time_value": "30"},
                         "45": {"power_off_timer": "on", "power_off_time_value": "45"},
                         "60": {"power_off_timer": "on", "power_off_time_value": "60"},
-                    }
+                    },
                 },
             },
             Platform.SENSOR: {
                 "water_full_time": {
                     "device_class": SensorDeviceClass.DURATION,
                     "unit_of_measurement": UnitOfTime.MINUTES,
-                    "state_class": SensorStateClass.MEASUREMENT
+                    "state_class": SensorStateClass.MEASUREMENT,
                 },
                 "water_full_level": {
-                    "device_class": SensorDeviceClass.ENUM
+                    "device_class": SensorDeviceClass.ENUM,
                 },
-            }
-        }
-    }
+            },
+        },
+    },
+    "20104032": {
+        "rationale": ["off", "on"],
+        "queries": [{}, {"query_type": "light,sound"}],
+        "centralized": [],
+        "entities": {
+            Platform.SWITCH: {
+                "power": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "anion": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "child_lock": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "wind_swing_ud": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "filter_tip": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                    "rationale": [0, 1],
+                },
+                "purifier": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "dry": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "light": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                    "rationale": [0, 1],
+                },
+                "sound": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                    "rationale": [0, 1],
+                },
+            },
+            Platform.HUMIDIFIER: {
+                "dehumidifier": {
+                    "device_class": HumidifierDeviceClass.HUMIDIFIER,
+                    "power": "power",
+                    "target_humidity": "humidity",
+                    "current_humidity": "cur_humidity",
+                    "mode": "mode",
+                    "min_humidity": 35,
+                    "max_humidity": 85,
+                    "modes": {
+                        "set": {"mode": "set"},
+                        "continuity": {"mode": "continuity"},
+                        "eco": {"mode": "eco"},
+                        "dry_clothes": {"mode": "dry_clothes"},
+                    },
+                },
+            },
+            Platform.BINARY_SENSOR: {
+                "tank_status": {
+                    "device_class": BinarySensorDeviceClass.PROBLEM,
+                },
+                "filter_value": {
+                    "device_class": BinarySensorDeviceClass.PROBLEM,
+                },
+                "water_pump": {
+                    "device_class": BinarySensorDeviceClass.RUNNING,
+                },
+                "water_pump_enable": {
+                },
+            },
+            Platform.SELECT: {
+                "wind_speed": {
+                    "options": {
+                        "silent": {"wind_speed": "20"},
+                        "comfortable": {"wind_speed": "60"},
+                        "high": {"wind_speed": "80"},
+                        "turbo": {"wind_speed": "100"},
+                    },
+                },
+                "power_on_time": {
+                    "options": {
+                        "off": {"power_on_timer": "off", "power_on_time_value": 0},
+                        "15": {"power_on_timer": "on", "power_on_time_value": 1},
+                        "30": {"power_on_timer": "on", "power_on_time_value": 2},
+                        "45": {"power_on_timer": "on", "power_on_time_value": 3},
+                        "60": {"power_on_timer": "on", "power_on_time_value": 4},
+                    },
+                },
+                "power_off_time": {
+                    "options": {
+                        "off": {"power_off_timer": "off", "power_off_time_value": 0},
+                        "15": {"power_off_timer": "on", "power_off_time_value": 1},
+                        "30": {"power_off_timer": "on", "power_off_time_value": 2},
+                        "45": {"power_off_timer": "on", "power_off_time_value": 3},
+                        "60": {"power_off_timer": "on", "power_off_time_value": 4},
+                    },
+                },
+            },
+            Platform.SENSOR: {
+                "water_full_time": {
+                    "device_class": SensorDeviceClass.DURATION,
+                    "unit_of_measurement": UnitOfTime.MINUTES,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+                "water_full_level": {
+                    "device_class": SensorDeviceClass.ENUM,
+                },
+                "error_code": {
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+                "version": {
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+            },
+        },
+    },
 }

--- a/custom_components/midea_auto_cloud/device_mapping/T0xA1.py
+++ b/custom_components/midea_auto_cloud/device_mapping/T0xA1.py
@@ -1,8 +1,8 @@
 from homeassistant.components.humidifier import HumidifierDeviceClass
-from homeassistant.components.sensor import SensorStateClass, SensorDeviceClass
-from homeassistant.components.switch import SwitchDeviceClass
-from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.const import Platform, UnitOfTime
+from homeassistant.components.sensor import SensorStateClass, SensorDeviceClass
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.switch import SwitchDeviceClass
 
 DEVICE_MAPPING = {
     "default": {

--- a/custom_components/midea_auto_cloud/translations/en.json
+++ b/custom_components/midea_auto_cloud/translations/en.json
@@ -357,6 +357,15 @@
       },
       "on_seat": {
         "name": "On Seat"
+      },
+      "filter_value": {
+        "name": "Filter Status"
+      },
+      "water_pump": {
+        "name": "Water Pump"
+      },
+      "water_pump_enable": {
+        "name": "Water Pump Enabled"
       }
     },
     "climate": {
@@ -595,7 +604,17 @@
         "name": "Humidifier"
       },
       "dehumidifier": {
-        "name": "Dehumidifier"
+        "name": "Dehumidifier",
+        "state_attributes": {
+          "mode": {
+            "state": {
+              "set": "Set",
+              "continuity": "Continuous",
+              "eco": "Eco",
+              "dry_clothes": "Dry Clothes"
+            }
+          }
+        }
       }
     },
     "select": {
@@ -1188,12 +1207,14 @@
       "wind_speed": {
         "name": "Wind Speed",
         "state": {
-          "low": "low",
           "medium": "medium",
           "middle": "middle",
-          "high": "high",
+          "high": "High",
           "auto": "auto",
-          "invalid": "invalid"
+          "invalid": "invalid",
+          "silent": "Silent",
+          "comfortable": "Comfortable",
+          "turbo": "Turbo"
         }
       },
       "work_mode": {
@@ -2640,7 +2661,7 @@
       "total_elec_value": {
         "name": "Total Electricity"
       },
-	    "clean_water_consumption_next_remaining": {
+      "clean_water_consumption_next_remaining": {
         "name": "Clean Water Consumption Next Remaining"
       },
       "clean_interval_next_days_remaining": {
@@ -3997,6 +4018,9 @@
       },
       "wind_swing_ud_right": {
         "name": "Wind Swing UD Right"
+      },
+      "sound": {
+        "name": "Buzzer"
       }
     },
     "vacuum": {

--- a/custom_components/midea_auto_cloud/translations/zh-Hans.json
+++ b/custom_components/midea_auto_cloud/translations/zh-Hans.json
@@ -377,6 +377,15 @@
       },
       "on_seat": {
         "name": "坐圈状态"
+      },
+      "filter_value": {
+        "name": "滤网状态"
+      },
+      "water_pump": {
+        "name": "水泵"
+      },
+      "water_pump_enable": {
+        "name": "水泵启用"
       }
     },
     "climate": {
@@ -639,7 +648,17 @@
         }
       },
       "dehumidifier": {
-        "name": "除湿器"
+        "name": "除湿器",
+        "state_attributes": {
+          "mode": {
+            "state": {
+              "set": "设定",
+              "continuity": "连续除湿",
+              "eco": "节能",
+              "dry_clothes": "干衣"
+            }
+          }
+        }
       }
     },
     "select": {
@@ -1381,12 +1400,14 @@
       "wind_speed": {
         "name": "风速",
         "state": {
-          "low": "低速",
           "medium": "中速",
           "middle": "中速",
           "high": "高速",
           "auto": "自动",
-          "invalid": "无效"
+          "invalid": "无效",
+          "silent": "静音",
+          "comfortable": "舒适",
+          "turbo": "强劲"
         }
       },
       "work_mode": {
@@ -4352,6 +4373,9 @@
       },
       "wind_swing_ud_right": {
         "name": "上下摆风(右)"
+      },
+      "sound": {
+        "name": "蜂鸣器"
       }
     },
     "vacuum": {


### PR DESCRIPTION
## 概述

为 SN8 为 `20104032` 的除湿机新增自定义配置。**未修改 `default` 默认配置**，仅新增 SN8 专属条目。

## 新增实体（仅对 SN8=20104032 生效）

### 开关 (Switch)
- **净化开关** (`purifier`) — 空气净化功能
- **干燥开关** (`dry`) — 干燥模式
- **屏显开关** (`light`) — 控制显示屏
- **蜂鸣器开关** (`sound`) — 控制蜂鸣提示音

### 二进制传感器 (Binary Sensor)
- **滤网状态** (`filter_value`)
- **水泵运行** (`water_pump`)
- **水泵启用** (`water_pump_enable`)

### 传感器 (Sensor)
- **错误码** (`error_code`)
- **固件版本** (`version`)

## 修改内容（仅对 SN8=20104032 生效）

- 风速档位从 2 档扩展为 4 档（静音20/舒适60/高速80/强劲100）
- 模式调整为 set设定/eco节能/continuity连续/dry_clothes干衣
- 新增 light/sound 的 B1 扩展查询以支持屏显和蜂鸣器读写

## 测试

已在 SN8=20104032 的美的除湿机上实际测试验证通过。