### PR TITLE
fix: coerce server selection to int in config flow

### DIFF
--- a/custom_components/midea_auto_cloud/config_flow.py
+++ b/custom_components/midea_auto_cloud/config_flow.py
@@ -128,7 +128,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema({
                 vol.Required(CONF_ACCOUNT): str,
                 vol.Required(CONF_PASSWORD): str,
-                vol.Required(CONF_SERVER, default=2): vol.In(CONF_SERVERS)
+                # Coerce before vol.In: recent Home Assistant frontends submit the
+                # selected value as a string ("1"/"2"), which vol.In with the integer
+                # CONF_SERVERS keys rejects ("value must be one of [1, 2]"). Coercing
+                # accepts both string and int; the field still renders as a select.
+                vol.Required(CONF_SERVER, default=2): vol.All(vol.Coerce(int), vol.In(CONF_SERVERS))
             }),
             errors=errors,
         )
@@ -447,7 +451,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=vol.Schema({
                 vol.Required(CONF_ACCOUNT, default=current_data.get(CONF_ACCOUNT, "")): str,
                 vol.Required(CONF_PASSWORD, default=""): str,
-                vol.Required(CONF_SERVER, default=current_data.get(CONF_SERVER, 2)): vol.In(CONF_SERVERS)
+                # Same coercion as the login step; the default is int-coerced too in
+                # case an older config entry stored the server value as a string.
+                vol.Required(CONF_SERVER, default=int(current_data.get(CONF_SERVER) or 2)): vol.All(vol.Coerce(int), vol.In(CONF_SERVERS))
             }),
             errors=errors,
         )


### PR DESCRIPTION
## Problem

When adding the integration, choosing a server on the login screen fails with:

> value must be one of [1, 2]

and the **server radio button clears**, so the integration can't be added. Reported in #171 (HA 2026.x, reproduced across multiple browsers and devices).

## Cause

The login schema is `vol.Required(CONF_SERVER, default=2): vol.In(CONF_SERVERS)`, and `CONF_SERVERS` has **integer** keys (`{1: "MSmartHome", 2: "美的美居"}`). Recent Home Assistant frontends submit the selected value as a **string** (`"1"`/`"2"`). `vol.In` with integer keys rejects the string, which produces the error and clears the field.

## Fix

Wrap the validator with `vol.Coerce(int)` — `vol.All(vol.Coerce(int), vol.In(CONF_SERVERS))` — so both string and integer values are accepted and coerced to the integer key the rest of the flow already expects. Applied to the login step and the change-credentials step (whose `default` is also int-coerced, in case an older entry stored the value as a string).

## Verification

Checked with `voluptuous` + `voluptuous_serialize`:

- **Before:** the schema rejects `"1"`/`"2"`, accepts only ints.
- **After:** accepts `"1"`, `"2"`, `1`, `2` (all coerce to int) **and still serializes as a `select`**, so the dropdown/radio renders unchanged.

Fixes #171
