### PR TITLE
feat: add hvac_action and compressor/fan run-status sensors

### DIFF
--- a/custom_components/midea_auto_cloud/climate.py
+++ b/custom_components/midea_auto_cloud/climate.py
@@ -2,6 +2,7 @@ from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityFeature,
     HVACMode,
+    HVACAction,
     ATTR_HVAC_MODE,
     ATTR_TARGET_TEMP_LOW,
     ATTR_TARGET_TEMP_HIGH,
@@ -85,6 +86,12 @@ class MideaClimateEntity(MideaEntity, ClimateEntity):
         self._key_target_temperature_low = self._config.get("target_temperature_low")
         self._key_target_temperature_high = self._config.get("target_temperature_high")
         self._range_hvac_modes = self._config.get("range_hvac_modes") or []
+        # Optional runtime-status attributes for hvac_action: which device
+        # attribute reports the compressor / indoor-fan run state, and the
+        # auto-resolved cooling/heating direction.
+        self._key_action_compressor = self._config.get("action_compressor")
+        self._key_action_fan = self._config.get("action_fan")
+        self._key_action_direction = self._config.get("action_direction")
         self._key_min_humidity = self._config.get("min_humidity")
         self._key_max_humidity = self._config.get("max_humidity")
         self._key_current_humidity = self._config.get("current_humidity")
@@ -330,6 +337,72 @@ class MideaClimateEntity(MideaEntity, ClimateEntity):
     @property
     def hvac_modes(self):
         return list(self._key_hvac_modes.keys())
+
+    @staticmethod
+    def _is_running(value) -> bool:
+        return value in (1, "1", True, "on", "true")
+
+    def _running_direction(self) -> "HVACAction":
+        """Cooling vs heating while the compressor is running.
+
+        Explicit cool/heat modes are unambiguous. For auto/range mode we read the
+        device's resolved direction from action_direction
+        (auto_mode_actual_operating_status): 1 = cooling, 2 = heating — confirmed
+        empirically on the T0x44 (cooling and idle reported 1; a real heating
+        cycle reported 2, cross-checked against the Midea app). Falls back to
+        room-vs-band if that value is missing or unexpected, so other variants
+        degrade gracefully instead of misreporting.
+        """
+        mode = self.hvac_mode
+        if mode == HVACMode.HEAT:
+            return HVACAction.HEATING
+        if mode == HVACMode.COOL:
+            return HVACAction.COOLING
+        if self._key_action_direction is not None:
+            d = self._get_nested_value(self._key_action_direction)
+            if d in (1, "1"):
+                return HVACAction.COOLING
+            if d in (2, "2"):
+                return HVACAction.HEATING
+        cur = self.current_temperature
+        if cur is not None and self._uses_temperature_range():
+            hi = self.target_temperature_high
+            lo = self.target_temperature_low
+            if lo is not None and cur <= lo:
+                return HVACAction.HEATING
+            if hi is not None and cur >= hi:
+                return HVACAction.COOLING
+        return HVACAction.COOLING
+
+    @property
+    def hvac_action(self):
+        """What the equipment is actually doing (running vs idle).
+
+        Only active when the mapping provides the run-status / direction keys, so
+        other device types are unaffected (returns None). Running vs idle comes
+        from the compressor/fan run-status flags; cooling vs heating from
+        _running_direction:
+          off -> OFF; compressor running -> COOLING/HEATING; only fan -> FAN;
+          otherwise -> IDLE.
+        """
+        if (self._key_action_compressor is None and self._key_action_fan is None
+                and self._key_action_direction is None):
+            return None
+        if not self.is_on:
+            return HVACAction.OFF
+        compressor = (
+            self._is_running(self._get_nested_value(self._key_action_compressor))
+            if self._key_action_compressor else False
+        )
+        fan = (
+            self._is_running(self._get_nested_value(self._key_action_fan))
+            if self._key_action_fan else False
+        )
+        if compressor:
+            return self._running_direction()
+        if fan:
+            return HVACAction.FAN
+        return HVACAction.IDLE
 
     @property
     def is_aux_heat(self):

--- a/custom_components/midea_auto_cloud/device_mapping/T0x44.py
+++ b/custom_components/midea_auto_cloud/device_mapping/T0x44.py
@@ -4,6 +4,7 @@ from homeassistant.const import (
 )
 from homeassistant.components.sensor import SensorStateClass, SensorDeviceClass
 from homeassistant.components.switch import SwitchDeviceClass
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 
 DEVICE_MAPPING = {
     "default": {
@@ -55,6 +56,23 @@ DEVICE_MAPPING = {
                     "max_temp": "set_temperature_upper_limit",
                     "temperature_unit": "temperature_unit",
                     "precision": PRECISION_WHOLE,
+                    # Surface running/idle on the climate card via hvac_action.
+                    # Direction in auto mode: auto_mode_actual_operating_status
+                    # (1 = cooling, 2 = heating), confirmed against the Midea app.
+                    "action_compressor": "outdoor_compressor_operating_status",
+                    "action_fan": "indoor_fan_run_status",
+                    "action_direction": "auto_mode_actual_operating_status",
+                },
+            },
+            Platform.BINARY_SENSOR: {
+                # 0 = idle, 1 = running (generic binary sensor: on when value == 1)
+                "outdoor_compressor_operating_status": {
+                    "device_class": BinarySensorDeviceClass.RUNNING,
+                    "name": "Compressor",
+                },
+                "indoor_fan_run_status": {
+                    "device_class": BinarySensorDeviceClass.RUNNING,
+                    "name": "Indoor Fan",
                 },
             },
             Platform.SELECT: {


### PR DESCRIPTION
## Summary

Surface the runtime state the T0x44 thermostat already reports but the integration didn't expose. Implements the feature discussed and approved in #179.

- Two `binary_sensor` entities (device_class `running`): **Compressor** and **Indoor Fan**, from `outdoor_compressor_operating_status` and `indoor_fan_run_status` (on when value == 1).
- A climate **`hvac_action`**: `off` when powered off → `cooling`/`heating` when the compressor runs → `fan` if only the fan runs → otherwise `idle`. Direction comes from the explicit hvac mode, or in auto from `action_direction`.

## Design (per #179)

Mapping-driven and gated behind optional climate keys — `action_compressor`, `action_fan`, `action_direction` — exactly as discussed. When a mapping doesn't set them, `hvac_action` returns `None` and no extra sensors are added, so **other device types are unaffected**. Wired up for T0x44; any other T0x type can opt in by adding the keys plus a `BINARY_SENSOR` section.

## On the direction mapping (your note in #179)

`action_direction` → `auto_mode_actual_operating_status`, with **1 = cooling, 2 = heating**. I confirmed this on a T0x44 / M-Station MTL04-1 by forcing both a cooling and a heating cycle and cross-checking against the Midea SmartHome app (cooling and idle reported 1; an active heating cycle reported 2).

To stay safe if another T0x44 variant encodes it differently, `_running_direction()` only trusts `action_direction` for the values 1/2; otherwise it falls back to room-temp-vs-band (using the auto low/high limits from #176), then a safe default. So a mismatch degrades to an inference rather than a wrong or raised state.

## Changes

- `climate.py`: add `hvac_action` + helpers, gated on the new `action_*` keys (imports `HVACAction`).
- `device_mapping/T0x44.py`: wire the three `action_*` keys and add a `BINARY_SENSOR` section for Compressor / Indoor Fan.

## Testing

Tested on a T0x44 (M-Station MTL04-1, Midea evoX G3) on Home Assistant 2026.6: the two binary sensors track the compressor/fan correctly (both 0→1 transitions verified live), and the climate card shows Cooling / Heating / Idle / Off as expected (heating direction verified during a forced heat cycle). Running 24h+ stable.

Discussed in #179.

(Implemented by Claude Code Opus 4.8, tested on my T0x44 / M-Station MTL04-1 Evox G3 HVAC systems)
